### PR TITLE
Fix jade doctype deprecation

### DIFF
--- a/Support/template.jade
+++ b/Support/template.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html
   head
     meta(charset='utf-8')

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies" : {
     "coffee-script":  "*",
     "coffeelint" :  "*",
-    "jade" :  "*"
+    "jade" :  "1.3.0"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
The jade syntax of `!!! 5` for defining the doctype has been deprecated in favour of `doctype html`.
This pull fixes the deprecation and locks in the jade version.
