### PR TITLE
Fix links to files in output window

### DIFF
--- a/Support/template.jade
+++ b/Support/template.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html
   head
     meta(charset='utf-8')

--- a/Support/template.jade
+++ b/Support/template.jade
@@ -22,7 +22,7 @@ html
         ul.problems        
           for err in errors
             li
-              a(href='txmt://open?url=#{filepath}&line=#{err.lineNumber}')
+              a(href='txmt://open?url=file://#{filepath}&line=#{err.lineNumber}')
                 span.location Line #{err.lineNumber}
                 span.desc #{err.message}
                 pre !{err.line}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies" : {
     "coffee-script":  "*",
     "coffeelint" :  "*",
-    "jade" :  "*"
+    "jade" :  "1.3.0"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Links back to files in TextMate need to include "file protocol" eg `txmt://open?url=file:///Path/to/file`
_Or at least this is the case with TextMate2_
